### PR TITLE
Update cleaning tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ let watchingFiles = false;
 
 /* Utility */
 gulp.task('clean:site', function() {
-  return gulp.src(`${OUTPUT_SITE}/**/*`)
+  return gulp.src(`${OUTPUT_SITE}/**/{.,}*`)
              .pipe(remove());
 });
 gulp.task('clean:reports', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,11 +61,11 @@ let watchingFiles = false;
 
 /* Utility */
 gulp.task('clean:site', function() {
-  return gulp.src(`${OUTPUT_SITE}/**/{.,}*`)
+  return gulp.src(`${OUTPUT_SITE}/**/{.,}*`, { read: false })
              .pipe(remove());
 });
 gulp.task('clean:reports', function() {
-  return gulp.src(`${OUTPUT_REPORTS}/**/*`)
+  return gulp.src(`${OUTPUT_REPORTS}/**/*`, { read: false })
              .pipe(remove());
 });
 gulp.task('clean', gulp.parallel('clean:reports', 'clean:site'));


### PR DESCRIPTION
- Remove dot files in `site:clean` task
- Improve performance of cleaning tasks. As per [the documentation](https://www.npmjs.com/package/gulp-rm#usage):
> Passing `{ read: false }` to `gulp.src()` prevents gulp from reading in the contents of files and thus speeds up the whole process.