### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ npm-debug.log
 # generated files
 _reports/
 _site/
+tests/_artifacts/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# NodeJS
+node_modules/
+npm-debug.log
+
+# generated files
+_reports/
+_site/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,26 @@
 FROM node:10-alpine
 
-# Install Make and Python for node-gyp
-RUN apk add --no-cache g++ make python
+# Install prerequisites for node-gyp
+RUN apk add --no-cache \
+  g++ \
+  make \
+  python
+
+# Install Chomium for puppeteer
+RUN apk add --no-cache \
+  chromium \
+  nss \
+  freetype \
+  freetype-dev \
+  harfbuzz \
+  ca-certificates \
+  ttf-freefont
+
+# Configure Puppeteer
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+  PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
+  PUPPETEER_NO_SANDBOX=true \
+  PUPPETEER_HEADLESS=true
 
 # Install portfolio dependencies
 WORKDIR /usr/src/portfolio

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,13 @@ RUN apk add --no-cache \
   make \
   python
 
+# Install prerequisites for gulp-imagemin
+RUN apk add --no-cache \
+  autoconf \
+  automake \
+  libtool \
+  nasm
+
 # Install Chomium for puppeteer
 RUN apk add --no-cache \
   chromium \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:10
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install
+RUN npm install -g gulp
+
+COPY . .
+
+EXPOSE 4000
+CMD ["gulp", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM node:10
+FROM node:10-alpine
 
-WORKDIR /usr/src/app
+# Install Make and Python for node-gyp
+RUN apk add --no-cache g++ make python
 
+# Install portfolio dependencies
+WORKDIR /usr/src/portfolio
 COPY package*.json ./
 RUN npm install
 RUN npm install -g gulp
 
+# Copy the portfolio
 COPY . .
 
+# Expose port and run server
 EXPOSE 4000
-CMD ["gulp", "serve"]
+ENTRYPOINT ["gulp", "serve"]

--- a/README.md
+++ b/README.md
@@ -30,3 +30,43 @@ Repository for the personal portfolio of Eric Cornelissen.
 - `$ gulp server`: Start a simple HTTP server (on port 4000) serving the site.
   - Requires `$ gulp build` or `$ gulp dist`.
 - `$ gulp test`: Run the test suites of the project.
+
+### Docker
+To serve the portfolio from a [Docker](https://www.docker.com/) image run:
+
+```bash
+# Build the docker image to run the portfolio
+$ docker build -t portfolio-eric .
+
+# Run the docker image as a container to start a web server
+$ docker run -p 4000:4000 -d portfolio-eric
+```
+
+To check the log of the web server.
+
+```bash
+# Find the image using
+$ docker ps
+CONTAINER ID   IMAGE            COMMAND   CREATED   STATUS   PORTS        NAMES
+[ID]           portfolio-eric   ...       ...       ...      4000->4000   ...
+...
+
+# Copy the value [ID] under "CONTAINER ID"
+$ docker logs [ID]
+```
+
+To remove the container or image
+
+```bash
+# To remove the docker container for the portfolio run
+$ docker ps -a
+CONTAINER ID   IMAGE            COMMAND   CREATED   STATUS   PORTS        NAMES
+[ID]           portfolio-eric   ...       ...       ...      4000->4000   ...
+...
+
+$ docker rm [ID]
+[ID]
+
+# To remove the docker image run
+$ docker image rm portfolio-eric
+```

--- a/README.md
+++ b/README.md
@@ -35,38 +35,15 @@ Repository for the personal portfolio of Eric Cornelissen.
 To serve the portfolio from a [Docker](https://www.docker.com/) image run:
 
 ```bash
-# Build the docker image to run the portfolio
+# Build the Docker image to run the portfolio
 $ docker build -t portfolio-eric .
 
-# Run the docker image as a container to start a web server
-$ docker run -p 4000:4000 -d portfolio-eric
-```
+# Run the Docker image as a container to start a web server
+$ docker run -d --rm -p 4000:4000 --name portfolio-server portfolio-eric
 
-To check the log of the web server.
+# Check the server logs
+$ docker logs portfolio-server
 
-```bash
-# Find the image using
-$ docker ps
-CONTAINER ID   IMAGE            COMMAND   CREATED   STATUS   PORTS        NAMES
-[ID]           portfolio-eric   ...       ...       ...      4000->4000   ...
-...
-
-# Copy the value [ID] under "CONTAINER ID"
-$ docker logs [ID]
-```
-
-To remove the container or image
-
-```bash
-# To remove the docker container for the portfolio run
-$ docker ps -a
-CONTAINER ID   IMAGE            COMMAND   CREATED   STATUS   PORTS        NAMES
-[ID]           portfolio-eric   ...       ...       ...      4000->4000   ...
-...
-
-$ docker rm [ID]
-[ID]
-
-# To remove the docker image run
-$ docker image rm portfolio-eric
+# To stop the web server (and delete the container)
+$ docker stop portfolio-server
 ```

--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ $ docker logs portfolio-server
 # To stop the web server (and delete the container)
 $ docker stop portfolio-server
 ```
+
+Alternatively, you can use Gulp commands to execute the above commands:
+
+- `gulp docker:build`: build the Docker image from the Dockerfile.
+- `gulp docker:rmi`: remove the Docker image from the system.
+- `gulp docker:start`: start a Docker container from the image.
+- `gulp docker:stop`: stop (and remove) the Docker container.
+- `gulp docker:logs`: shows the logs of the Docker container.
+- `gulp docker:attach`: attach a shell to the Docker container.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ const postcss = require('gulp-postcss');
 const remove = require('gulp-rm');
 const replaceExt = require('gulp-ext-replace');
 const run = require('gulp-run-command').default;
+const shell = require('gulp-shell');
 const stylelint = require('gulp-stylelint');
 const uglifyJS = require('gulp-uglify-es').default;
 
@@ -55,6 +56,9 @@ const OUTPUT_REPORTS = './_reports';
 
 const TEST_DIR = './tests';
 const TEST_FILES = `${TEST_DIR}/**/*.js`;
+
+const DOCKER_IMAGE_NAME = 'portfolio-eric';
+const DOCKER_CONTAINER_NAME = 'portfolio-server';
 
 
 let minifyOutput = false;
@@ -306,6 +310,14 @@ gulp.task('lint', gulp.parallel('lint-json', 'lint-html', 'lint-scripts', 'lint-
 /* Testing */
 const testIntegration = run('./node_modules/.bin/jest');
 gulp.task('test', gulp.series('clean:site', 'clean:tests', 'build', 'server', sleep(isCI ? 10000 : 0), testIntegration, gracefulExit));
+
+/* Docker */
+gulp.task('docker:build', run(`docker build -t ${DOCKER_IMAGE_NAME} .`));
+gulp.task('docker:rmi', run(`docker rmi ${DOCKER_IMAGE_NAME}`));
+gulp.task('docker:start', run(`docker run -d --rm -p 4000:4000 --name ${DOCKER_CONTAINER_NAME} ${DOCKER_IMAGE_NAME}`));
+gulp.task('docker:stop', run(`docker stop ${DOCKER_CONTAINER_NAME}`));
+gulp.task('docker:logs', run(`docker logs ${DOCKER_CONTAINER_NAME}`));
+gulp.task('docker:attach', shell.task(`docker exec -it  ${DOCKER_CONTAINER_NAME} /bin/sh -c "[ -e /bin/bash ] && /bin/bash || /bin/sh"`));
 
 /* Default */
 gulp.task('default', gulp.series('clean:site', 'serve'));

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  launch: {
+    args: [
+      process.env.PUPPETEER_NO_SANDBOX ? '--no-sandbox' : ''
+    ],
+    headless: process.env.PUPPETEER_HEADLESS !== 'false'
+  },
+  browser: 'chromium',
+  browserContext: 'default'
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9005,6 +9005,72 @@
         }
       }
     },
+    "gulp-shell": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.8.0.tgz",
+      "integrity": "sha512-wHNCgmqbWkk1c6Gc2dOL5SprcoeujQdeepICwfQRo91DIylTE7a794VEE+leq3cE2YDoiS5ulvRfKVIEMazcTQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "fancy-log": "^1.3.3",
+        "lodash.template": "^4.5.0",
+        "plugin-error": "^1.0.1",
+        "through2": "^3.0.1",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "gulp-spawn": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/gulp-spawn/-/gulp-spawn-0.4.5.tgz",
@@ -20713,6 +20779,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "ttf2eot": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-postcss": "8.0.0",
     "gulp-rm": "2.0.0",
     "gulp-run-command": "0.0.10",
+    "gulp-shell": "0.8.0",
     "gulp-stylelint": "13.0.0",
     "gulp-uglify-es": "2.0.0",
     "handlebars-helpers": "0.10.0",


### PR DESCRIPTION
Add support to run the webserver of the portfolio with [Docker](https://www.docker.com/). This was put together based largely on the [Dockerizing a Node.js web app](https://nodejs.org/fr/docs/guides/nodejs-docker-webapp/) article and using the [Docker docs](https://docs.docker.com/).