### PR TITLE
Attach local workspace to Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,23 @@ of commands that analyze the source code can be found in `./_reports`.
 
 ## Docker
 
-To serve the portfolio from a [Docker] image run:
+You can use [Gulp] commands to run the server for this portfolio from a [Docker]
+image:
+
+- `gulp docker:build`: build the Docker image for the project.
+- `gulp docker:rmi`: remove the Docker of the project image from the system.
+- `gulp docker:start`: start a Docker container with a server for the portfolio.
+  This image will be attached to local workspace so that local changes are
+  immediately reflected by the server.
+- `gulp docker:stop`: stop (and remove) the Docker container.
+- `gulp docker:logs`: shows the logs of the Docker container.
+- `gulp docker:attach`: attach a shell to the Docker container.
+
+Alternatively, you can serve the portfolio from a [Docker] image by running
+commands along the lines of:
 
 ```bash
-# Build the Docker image to run the portfolio
+# Build the Docker image to serve the portfolio
 $ docker build -t portfolio-eric .
 
 # Run the Docker image as a container to start a web server
@@ -51,18 +64,9 @@ $ docker run -d --rm -p 4000:4000 --name portfolio-server portfolio-eric
 # Check the server logs
 $ docker logs portfolio-server
 
-# To stop the web server (and delete the container)
+# To stop the web server and delete the container
 $ docker stop portfolio-server
 ```
-
-Alternatively, you can use [Gulp] commands to execute the above commands:
-
-- `gulp docker:build`: build the Docker image from the Dockerfile.
-- `gulp docker:rmi`: remove the Docker image from the system.
-- `gulp docker:start`: start a Docker container from the image.
-- `gulp docker:stop`: stop (and remove) the Docker container.
-- `gulp docker:logs`: shows the logs of the Docker container.
-- `gulp docker:attach`: attach a shell to the Docker container.
 
 [aXe]: https://www.axe-core.org/
 [browser-sync]: https://browsersync.io/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,6 +62,7 @@ const TEST_FILES = `${TEST_DIR}/**/*.js`;
 const SERVER_PORT = 4000;
 
 const DOCKER_IMAGE_NAME = 'portfolio-eric';
+const DOCKER_IMAGE_WORKDIR = '/usr/src/portfolio';
 const DOCKER_CONTAINER_NAME = 'portfolio-server';
 
 
@@ -347,7 +348,7 @@ gulp.task('test', gulp.series('clean:site', 'clean:tests', 'build', 'server', sl
 /* Docker */
 gulp.task('docker:build', run(`docker build -t ${DOCKER_IMAGE_NAME} .`));
 gulp.task('docker:rmi', run(`docker rmi ${DOCKER_IMAGE_NAME}`));
-gulp.task('docker:start', run(`docker run -d --rm -p ${SERVER_PORT}:${SERVER_PORT} --name ${DOCKER_CONTAINER_NAME} ${DOCKER_IMAGE_NAME}`));
+gulp.task('docker:start', run(`docker run -d --rm -v ${process.env.PWD}:${DOCKER_IMAGE_WORKDIR} -p ${SERVER_PORT}:${SERVER_PORT} --name ${DOCKER_CONTAINER_NAME} ${DOCKER_IMAGE_NAME}`));
 gulp.task('docker:stop', run(`docker stop ${DOCKER_CONTAINER_NAME}`));
 gulp.task('docker:logs', run(`docker logs ${DOCKER_CONTAINER_NAME}`));
 gulp.task('docker:attach', shell.task(`docker exec -it  ${DOCKER_CONTAINER_NAME} /bin/sh -c "[ -e /bin/bash ] && /bin/bash || /bin/sh"`));


### PR DESCRIPTION
The `gulp docker:start` command now attaches the local workspace to the docker image automatically. This allows one to continuously work in the local workspace and have the server running in the docker image be updated.