### PR TITLE
Improve Docker image build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
 FROM node:10-alpine
 
+RUN apk update
+
 # Install prerequisites for node-gyp
-RUN apk add --no-cache \
+RUN apk add \
   g++ \
   make \
   python
 
 # Install prerequisites for gulp-imagemin
-RUN apk add --no-cache \
+RUN apk add \
   autoconf \
   automake \
   libtool \
   nasm
 
 # Install Chomium for puppeteer
-RUN apk add --no-cache \
+RUN apk add \
   chromium \
   nss \
   freetype \
@@ -22,6 +24,8 @@ RUN apk add --no-cache \
   harfbuzz \
   ca-certificates \
   ttf-freefont
+
+RUN rm -rf /var/cache/apk/*
 
 # Configure Puppeteer
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \


### PR DESCRIPTION
Following [this StackOverflow thread](https://stackoverflow.com/questions/49118579/alpine-dockerfile-advantages-of-no-cache-vs-rm-var-cache-apk) this updates the Dockerfile such that the Docker cache is utilized better. This achieved by omitting the `--no-cache` flag on `apk add` (which was there to keep the image size small) and replacing it with running `apk update` up front and clearing the cache afterwards (see line 28).