### PR TITLE
Use `csp_evaluator` to continuously lint the CSP policy

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -53,6 +53,21 @@ jobs:
         uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
       - name: Lint
         run: make lint-ci
+  lint-csp:
+    name: Content Security Policy
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Install Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Install tooling
+        uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
+      - name: Lint
+        run: make lint-csp
   lint-shell:
     name: Shell scripts
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,17 @@ license-check: node_modules/ ## Check the third-party dependency licenses
 		--errors-only
 
 .PHONY: lint
-lint: lint-ci lint-md lint-sh lint-yaml ## Run lint-*
+lint: lint-ci lint-csp lint-md lint-sh lint-yaml ## Run lint-*
 
 .PHONY: lint-ci
 lint-ci: node_modules/ ## Lint GitHub Actions workflows
 	@SHELLCHECK_OPTS=$(SHELLCHECK_OPTS) \
 		$(MAYBE) actionlint
+
+.PHONY: lint-csp
+lint-csp: node_modules/ ## Lint the Content Security Policy (csp)
+	@node script/csp_evaluator-cli.js \
+		./data/csp.txt
 
 .PHONY: lint-md
 lint-md: node_modules/ ## Lint MarkDown files
@@ -101,7 +106,7 @@ data/%.json: data/%.yaml  node_modules/
 		npx js-yaml -- $(file) > $(subst yaml,json,$(file)); \
 	)
 
-www/%.html: www/%.pug  node_modules/ data/*.json script/pug-cli.js
+www/%.html: www/%.pug  node_modules/ data/*.json data/csp.txt script/pug-cli.js
 	@$(foreach \
 		file, \
 		$(filter %.pug,$+), \

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -4,3 +4,4 @@
 
 !.gitignore
 !*.yaml
+!csp.txt

--- a/data/csp.txt
+++ b/data/csp.txt
@@ -1,0 +1,9 @@
+default-src 'none';
+base-uri 'self';
+connect-src 'self';
+font-src 'self' https://fonts.gstatic.com;
+img-src 'self';
+script-src 'self';
+style-src 'self' https://fonts.googleapis.com;
+trusted-types 'none';
+require-trusted-types-for 'script';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@prettier/plugin-pug": "3.1.0",
         "anywhere": "1.6.0",
+        "csp_evaluator": "1.1.2",
         "husky": "9.1.1",
         "is-ci": "3.0.1",
         "js-yaml": "4.1.0",
@@ -1190,6 +1191,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csp_evaluator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.2.tgz",
+      "integrity": "sha512-f4NlhZFb8rS63ssX3/MYzzV/TOuoVJl/TlwWUIwDH7907WfYJjY3Cfjdtk1NKAbUmGlcHVK+NeeWbxWK2go4Ww==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "@prettier/plugin-pug": "3.1.0",
     "anywhere": "1.6.0",
+    "csp_evaluator": "1.1.2",
     "husky": "9.1.1",
     "is-ci": "3.0.1",
     "js-yaml": "4.1.0",

--- a/script/csp_evaluator-cli.js
+++ b/script/csp_evaluator-cli.js
@@ -1,0 +1,35 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { CspEvaluator } from "csp_evaluator/dist/evaluator.js";
+import { CspParser } from "csp_evaluator/dist/parser.js";
+
+/* --- HELPERS -------------------------------------------------------------- */
+
+function allowedFinding(finding) {
+	if (finding.directive === "script-src" && finding.value === "'self'") {
+		return false;
+	}
+
+	return true;
+}
+
+/* --- MAIN ----------------------------------------------------------------- */
+
+async function main() {
+	// read and parse
+	const dataPath = path.resolve(".", "data");
+	const cspFile = path.resolve(dataPath, "csp.txt");
+	const rawCsp = await fs.readFile(cspFile, { encoding: "utf-8" });
+	const parsed = new CspParser(rawCsp);
+
+	// evaluate
+	const evaluator = new CspEvaluator(parsed.csp);
+	const result = evaluator.evaluate().filter(allowedFinding);
+	if (result.length > 0) {
+		console.log(result);
+		process.exit(2);
+	}
+}
+
+main();

--- a/script/pug-cli.js
+++ b/script/pug-cli.js
@@ -34,10 +34,14 @@ async function main() {
 	const datas = await Promise.all(ps);
 	const locals = datas.reduce((acc, data) => ({ ...acc, ...data }), {});
 
+	const cspFile = path.resolve(dataPath, "csp.txt");
+	const csp = (await fs.readFile(cspFile)).toString().replace(/\n/g, "");
+
 	// compile
 	const filePath = path.resolve(".", file);
 	const html = pug.renderFile(filePath, {
 		...locals,
+		csp,
 		filename: file,
 		pretty: false,
 		debug: false,

--- a/www/index.pug
+++ b/www/index.pug
@@ -3,10 +3,7 @@ html(lang="en")
 	head
 		meta(charset="utf-8")
 		meta(name="viewport", content="width=device-width, initial-scale=1")
-		meta(
-			http-equiv="Content-Security-Policy",
-			content="default-src 'none';base-uri 'self';connect-src 'self' https:;font-src 'self' https://fonts.gstatic.com;img-src 'self' https:;script-src 'self' 'unsafe-inline';style-src 'self' https://fonts.googleapis.com;trusted-types 'none';require-trusted-types-for 'script';"
-		)
+		meta(http-equiv="Content-Security-Policy", content=csp)
 		meta(name="title", content="Eric Cornelissen")
 
 		link(href="/styles/reset.css", rel="stylesheet", type="text/css")


### PR DESCRIPTION
Relates to #90

## Summary

Add the [`csp_evaluator` package](https://www.npmjs.com/package/csp_evaluator) as a dependency and use it in a project-specific CLI to (continuously) "lint" (or verify if you will) the CSP used in this project. To support this, the CSP has been extracted from the Pug source code into a text file. This allows the "linter" to easily access (and thus evaluate) it and enables the Pug templating engine to inject the CSP into the HTML at build time.
