### PR TITLE
Set "Referrer-Policy" through a meta tag

### DIFF
--- a/www/index.pug
+++ b/www/index.pug
@@ -1,10 +1,13 @@
 doctype html
 html(lang="en")
 	head
-		meta(charset="utf-8")
-		meta(name="viewport", content="width=device-width, initial-scale=1")
 		meta(http-equiv="Content-Security-Policy", content=csp)
+		meta(http-equiv="Referrer-Policy", content="no-referrer")
+
+		meta(charset="utf-8")
+
 		meta(name="title", content="Eric Cornelissen")
+		meta(name="viewport", content="width=device-width, initial-scale=1")
 
 		link(href="/styles/reset.css", rel="stylesheet", type="text/css")
 		link(href="/styles/layout.css", rel="stylesheet", type="text/css")


### PR DESCRIPTION
## Summary

As per the HTTP Observatory Report for the current website on June 25, 2025, set a page-wide referrer policy with a `<meta>` element. This is based on the documentation at:
https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Referrer_policy

Also re-organize the `<meta>` tags to list the `http-equiv` entries first, as suggested in the above link. Correspondingly, sort the rest of the `<meta>` tags by type and alphabetically by name.