### PR TITLE
Replace `tibdex/github-app-token` by `actions/create-github-app-token`

### DIFF
--- a/.github/workflows/tooling.yaml
+++ b/.github/workflows/tooling.yaml
@@ -19,11 +19,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Create token to create Pull Request
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: automation-token
         with:
-          app_id: ${{ secrets.AUTOMATION_ID }}
-          private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+          app-id: ${{ secrets.AUTOMATION_ID }}
+          private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@040e69dec221145526b552d9a74e410851aaed23 # v1.1.3
         with:


### PR DESCRIPTION
Replace the (unofficial) former action, which has been archived, in favor of the (new and official) latter action.